### PR TITLE
Footer sticks

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -5,10 +5,10 @@ import { InfoBanner } from "./infobanner"
 export const Layout = ({ children }) => {
     return (
         <>
-            <div className="min-h-full">
+            <div className="h-screen">
                 <InfoBanner />
                 <Navbar />
-                <main>{children}</main>
+                <main className="min-h-full">{children}</main>
                 <Footer />
             </div>
             


### PR DESCRIPTION
By making the main div take the full content of the page, it ensures that the main content is at least full screen and push the footer to the bottom.

In reference to bug: https://github.com/Esfands/esfand-community-site/issues/8