### PR TITLE
Game thumbnail getting cut off

### DIFF
--- a/pages/events/boomermonth.tsx
+++ b/pages/events/boomermonth.tsx
@@ -56,7 +56,7 @@ export default function BoomerMonth(props) {
                                         {games.map((game) => (
                                             <li key={game.id} className="relative">
                                             <div className="aspect-h-7 block overflow-hidden rounded-lg">
-                                                <img src={game.box_art_url.replace('{width}', 138).replace('{height}', 190)} alt="" className="pointer-events-none object-cover group-hover:opacity-75" />
+                                                <img src={game.box_art_url.replace('{width}', 144).replace('{height}', 192)} alt="" className="pointer-events-none object-cover group-hover:opacity-75" />
                                             </div>
                                             <p className="pointer-events-none w-36 mt-2 block truncate text-sm font-medium text-white">{game.name}</p>
                                             </li>


### PR DESCRIPTION
Game thumbnails were getting cut off like in the picture below:
![bug-preview](https://i.gyazo.com/80377e223bf3ade96b80b3a78e9a5661.png)

It was fixed by increasing the width of the thumbnail.
![after](https://i.gyazo.com/688a02c628fd602a8d2715588776e2c9.png)